### PR TITLE
gulpfileのアップデート

### DIFF
--- a/.csscomb.json
+++ b/.csscomb.json
@@ -1,0 +1,33 @@
+{
+    "remove-empty-rulesets": true,
+    "always-semicolon": true,
+    "color-case": "lower",
+    "block-indent": "  ",
+    "color-shorthand": true,
+    "element-case": "lower",
+    "eof-newline": false,
+    "leading-zero": false,
+    "quotes": "single",
+    "sort-order-fallback": "abc",
+    "space-before-colon": "",
+    "space-after-colon": " ",
+    "space-before-combinator": " ",
+    "space-after-combinator": " ",
+    "space-between-declarations": "\n",
+    "space-before-opening-brace": " ",
+    "space-after-opening-brace": "\n",
+    "space-after-selector-delimiter": "",
+    "space-before-selector-delimiter": "",
+    "space-before-closing-brace": "\n",
+    "strip-spaces": true,
+    "tab-size": true,
+    "unitless-zero": true,
+    "vendor-prefix-align": true,
+    "sort-order": [ [
+        "position",
+        "top",
+        "right",
+        "bottom",
+        "left"
+    ]]
+}

--- a/.sprite-template
+++ b/.sprite-template
@@ -1,0 +1,71 @@
+{
+  // Default options
+  'functions': true,
+  'variableNameTransforms': ['dasherize']
+}
+
+{{#block "sprites"}}
+{{#each sprites}}
+${{strings.name_name}}: '{{name}}';
+${{strings.name_x}}: {{px.x}};
+${{strings.name_y}}: {{px.y}};
+${{strings.name_offset_x}}: {{px.offset_x}};
+${{strings.name_offset_y}}: {{px.offset_y}};
+${{strings.name_width}}: {{px.width}};
+${{strings.name_height}}: {{px.height}};
+${{strings.name_total_width}}: {{px.total_width}};
+${{strings.name_total_height}}: {{px.total_height}};
+${{strings.name_image}}: '{{{escaped_image}}}';
+${{strings.name}}: ({{px.x}}, {{px.y}}, {{px.offset_x}}, {{px.offset_y}}, {{px.width}}, {{px.height}}, {{px.total_width}}, {{px.total_height}}, '{{{escaped_image}}}', '{{name}}', );
+{{/each}}
+{{/block}}
+{{#block "spritesheet"}}
+${{spritesheet_info.strings.name_width}}: {{spritesheet.px.width}};
+${{spritesheet_info.strings.name_height}}: {{spritesheet.px.height}};
+${{spritesheet_info.strings.name_image}}: '{{{spritesheet.escaped_image}}}';
+${{spritesheet_info.strings.name_sprites}}: ({{#each sprites}}${{strings.name}}, {{/each}});
+${{spritesheet_info.strings.name}}: ({{spritesheet.px.width}}, {{spritesheet.px.height}}, '{{{spritesheet.escaped_image}}}', ${{spritesheet_info.strings.name_sprites}}, );
+{{/block}}
+
+{{#block "sprite-functions"}}
+{{#if options.functions}}
+@mixin sprite-width($sprite) {
+  width: nth($sprite, 5);
+}
+
+@mixin sprite-height($sprite) {
+  height: nth($sprite, 6);
+}
+
+@mixin sprite-position($sprite) {
+  $sprite-offset-x: nth($sprite, 3);
+  $sprite-offset-y: nth($sprite, 4);
+  background-position: $sprite-offset-x  $sprite-offset-y;
+}
+
+@mixin sprite-image($sprite) {
+  $sprite-image: nth($sprite, 9);
+  background-image: url(#{$sprite-image});
+}
+
+@mixin sprite($sprite) {
+  @include sprite-image($sprite);
+  @include sprite-position($sprite);
+  @include sprite-width($sprite);
+  @include sprite-height($sprite);
+}
+{{/if}}
+{{/block}}
+
+{{#block "spritesheet-functions"}}
+{{#if options.functions}}
+@mixin sprites($sprites) {
+  @each $sprite in $sprites {
+    $sprite-name: nth($sprite, 10);
+    .#{$sprite-name} {
+      @include sprite($sprite);
+    }
+  }
+}
+{{/if}}
+{{/block}}

--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ Elementの階層が深くなるとその分セレクタ名称も長くなるた�
 
 | 単語       | 説明        |
 |:-----------|:------------|
-| wrap       | block要素を囲む場合など、外側のコンテナ |
 | inner      | wrapに対する内側のコンテナ |
 | block      | コンテンツを内包するブロック |
 | slider     | スライドコンテンツ |
@@ -199,6 +198,7 @@ Elementの階層が深くなるとその分セレクタ名称も長くなるた�
 | heading    | 見出しを内包する要素 |
 | title      | タイトル |
 | subTitle   | サブタイトル |
+| content    | コンテンツ |
 | description| コンテンツ説明本文 |
 | caption    | 画像に対する説明 |
 | summary    | コンテンツの概要 |
@@ -253,14 +253,14 @@ CSS
 spriteフォルダに配置した画像ファイル名を指定する
 
 ~~~~
-@include sprite($name);
+@include sprite-ir($name);
 ~~~~
 
 ### モバイル対応
 別途定義済みの `r-sprite` mixinを使用
 
 ~~~~
-@include r-sprite($name);
+@include sprite-ir($name,$mobile:true);
 ~~~~
 
 ## JavaScript
@@ -272,4 +272,4 @@ JavaScriptは動的な表現が必要な際と、外部APIなどを利用する�
 - Browserifyで `build.js` に集約して出力される。
 
 
-策定　2015年2月22日
+策定　2016年3月12日

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -164,13 +164,23 @@ gulp.task('sprite', function() {
   var spriteData = gulp.src(imgPath + 'sprite/*.png')
     .pipe(gulpLoadPlugins.spritesmith({
       imgName: 'sprite.png',
-      cssName: '_sprite.scss'
+      imgPath: imgPath + 'sprite.png',
+      cssName: '_sprite.scss',
+      cssTemplate: '.sprite-template',
+      algorithm:'top-down',
+      padding: 20,
+      algorithmOpts : {
+        sort: false
+      }
     }));
 
   // minify images
   spriteData.img
     .pipe(buffer())
-    .pipe(gulpLoadPlugins.imagemin())
+    .pipe(gulpLoadPlugins.imagemin({
+      progressive: true,
+      use: [pngquant({quality: '70-80', speed: 1})]
+    }))
     .pipe(gulp.dest(imgPath))
     .pipe(browserSync.reload({ stream:true }));
 
@@ -183,7 +193,10 @@ gulp.task('sprite', function() {
 // optimize images
 gulp.task('imagemin', function() {
   return gulp.src(imgPath + '**/*.+(jpg|jpeg|png|gif|svg)')
-    .pipe(gulpLoadPlugins.imagemin())
+    .pipe(gulpLoadPlugins.imagemin({
+      progressive: true,
+      use: [pngquant({quality: '70-80', speed: 1})]
+    }))
     .pipe(gulp.dest(imgPath))
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,8 @@ var buffer          = require('vinyl-buffer');
 var source          = require('vinyl-source-stream');
 var runSequence     = require('run-sequence');
 var fs              = require('fs');
-
+var pngquant        = require( 'imagemin-pngquant' );
+var watchify        = require( 'watchify' );
 
 // 2. VARIABLES
 // - - - - - - - - - - - - - - -

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,9 +87,16 @@ gulp.task('browser-sync', function() {
 
 // Compile Jade to HTML
 gulp.task('jade', function() {
-  return gulp.src(jadePath + '*.jade')
+  return gulp.src([jadePath + '/**/!(_)*.jade'])
     .pipe(gulpLoadPlugins.data(function(file) {
       return require(jadePath + 'setting.json')
+    }))
+    .pipe(gulpLoadPlugins.plumber({
+      errorHandler: handleErrors
+    }))
+    .pipe(gulpLoadPlugins.changed(htmlPath, {
+      extension: '.html',
+      hashChanged: gulpLoadPlugins.changed.compareSha1Digest
     }))
     .pipe(gulpLoadPlugins.jade({ pretty: true }))
     .pipe(gulp.dest(htmlPath))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,8 +26,8 @@ var buffer          = require('vinyl-buffer');
 var source          = require('vinyl-source-stream');
 var runSequence     = require('run-sequence');
 var fs              = require('fs');
-var pngquant        = require( 'imagemin-pngquant' );
-var watchify        = require( 'watchify' );
+var pngquant        = require('imagemin-pngquant');
+var watchify        = require('watchify');
 
 // 2. VARIABLES
 // - - - - - - - - - - - - - - -
@@ -128,7 +128,7 @@ gulp.task('sass', function() {
     }))
     .pipe(gulpLoadPlugins.csscomb())
     .pipe(gulpLoadPlugins.csslint())
-    .pipe(gulp.dest(cssPath));
+    .pipe(gulp.dest(cssPath))
     .pipe( browserSync.reload( { stream:true } ) );
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -109,21 +109,27 @@ gulp.task('jade', function() {
 
 // Compile stylesheets with Ruby Sass
 gulp.task('sass', function() {
-  return gulpLoadPlugins.rubySass(scssPath, {
-      loadPath: [bowerPath + 'foundation-sites/scss', bowerPath + 'fontawesome/scss'],
-      style: 'nested',
+  return gulpLoadPlugins.rubySass(scssPath + '**/*.scss', {
+      loadPath: [
+        bowerPath + 'foundation-sites/scss',
+        bowerPath + 'fontawesome/scss'
+      ],
+      style: 'expanded',
       bundleExec: false,
       require: 'sass-globbing',
       sourcemap: false
     })
-    .on('error', function(err) { console.error('Error!', err.message); })
-    .pipe(gulpLoadPlugins.autoprefixer({
-      browsers: ['last 2 versions', 'ie 10', 'ie 9']
+    .pipe(gulpLoadPlugins.plumber({
+      errorHandler: handleErrors
+    }))
+    .pipe(gulpLoadPlugins.pleeease({
+      "autoprefixer": {"browsers": ["last 2 versions", "ie 10", "ie 9"]},
+      "minifier": false
     }))
     .pipe(gulpLoadPlugins.csscomb())
-    .pipe(gulpLoadPlugins.csso())
     .pipe(gulpLoadPlugins.csslint())
     .pipe(gulp.dest(cssPath));
+    .pipe( browserSync.reload( { stream:true } ) );
 });
 
 gulp.task('css', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -114,7 +114,7 @@ gulp.task('sass', function() {
         bowerPath + 'foundation-sites/scss',
         bowerPath + 'fontawesome/scss'
       ],
-      style: 'expanded',
+      style: 'nested',
       bundleExec: false,
       require: 'sass-globbing',
       sourcemap: false
@@ -132,8 +132,21 @@ gulp.task('sass', function() {
     .pipe( browserSync.reload( { stream:true } ) );
 });
 
-gulp.task('css', function() {
-  runSequence('sass');
+gulp.task('cssmin', function() {
+  gulp.src(cssPath + 'app.css')
+    .pipe(gulpLoadPlugins.rename({
+      suffix: '.min'
+    }))
+    .pipe(gulpLoadPlugins.csso())
+    .pipe(gulp.dest(cssPath));
+})
+
+gulp.task('css', function(callback) {
+  return runSequence(
+    'sass',
+    'cssmin',
+    callback
+  );
 });
 
 
@@ -262,7 +275,7 @@ gulp.task('watch', function() {
 gulp.task('default', ['browser-sync', 'sprite', 'watch', 'watchify'] );
 
 // When before distribute, 'dist' task will be executed.
-gulp.task('dist', ['jade', 'css', 'js', 'sprite', 'imagemin']);
+gulp.task('dist', ['jade', 'css', 'browserify', 'sprite', 'imagemin']);
 
 // 11. Functions
 // - - - - - - - - - - - - - - -

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -240,24 +240,26 @@ gulp.task('build', ['bower'], function() {
 
 // Watch tasks
 gulp.task('watch', function() {
-  // Watch Jade
-  gulp.watch([jadePath + '*', jadePath + '**/*'], ['jade']);
 
-  // Watch PHP. When you make WordPress theme, activate this.
-  //gulp.watch(['./*.php'], browserSync.reload);
+  // Watch Jade
+  gulpLoadPlugins.watch([jadePath + '*', jadePath + '**/*'], function(e){
+    gulp.start('jade');
+  });
 
   // Watch Sprite
-  gulp.watch([imgPath + 'sprite/*.png'], ['sprite']);
+  gulpLoadPlugins.watch([imgPath + 'sprite/*.png'], function(e){
+    gulp.start('sprite');
+  });
 
   // Watch Sass
-  gulp.watch([scssPath + '*', scssPath + '**/*'], ['css', browserSync.reload]);
+  gulpLoadPlugins.watch([scssPath + '*', scssPath + '**/*'], function(e){
+    gulp.start('sass');
+  });
 
-  // Watch JavaScript
-  gulp.watch([jsPath + 'src/*'], ['js', browserSync.reload]);
 });
 
 // Default tasks
-gulp.task('default', ['browser-sync', 'sprite', 'watch'] );
+gulp.task('default', ['browser-sync', 'sprite', 'watch', 'watchify'] );
 
 // When before distribute, 'dist' task will be executed.
 gulp.task('dist', ['jade', 'css', 'js', 'sprite', 'imagemin']);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gulp-changed": "^1.3.0",
     "gulp-csscomb": "^3.0.6",
     "gulp-csslint": "^0.2.2",
+    "gulp-csso": "^1.1.0",
     "gulp-data": "^1.2.1",
     "gulp-imagemin": "^2.4.0",
     "gulp-jade": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "foundation-start-kit",
   "uri": "https://funteractive.co.jp/",
   "description": "funteractive start kit with jade and foundation 6",
-  "version": "2.0.0",
+  "version": "2.1.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/funteractive/foundation-start-kit.git"
+  },
   "browserify": {
     "transform": [
       "debowerify"
@@ -13,25 +17,29 @@
     "browserify": "^13.0.0",
     "debowerify": "^1.3.1",
     "gulp": "^3.9.1",
-    "gulp-autoprefixer": "^3.1.0",
     "gulp-bower": "0.0.13",
-    "gulp-concat": "^2.6.0",
-    "gulp-concat-css": "^2.2.0",
+    "gulp-changed": "^1.3.0",
     "gulp-csscomb": "^3.0.6",
-    "gulp-csslint": "^0.2.0",
-    "gulp-csso": "^1.0.1",
+    "gulp-csslint": "^0.2.2",
     "gulp-data": "^1.2.1",
     "gulp-imagemin": "^2.4.0",
     "gulp-jade": "^1.1.0",
     "gulp-kss": "0.0.2",
     "gulp-load-plugins": "^1.2.0",
+    "gulp-notify": "^2.2.0",
+    "gulp-pleeease": "^2.0.2",
+    "gulp-plumber": "^1.1.0",
     "gulp-rename": "^1.2.2",
     "gulp-ruby-sass": "^2.0.6",
     "gulp-uglify": "^1.5.2",
+    "gulp-util": "^3.0.7",
+    "gulp-watch": "^4.3.5",
     "gulp.spritesmith": "^6.2.0",
+    "imagemin-pngquant": "^4.2.2",
     "rimraf": "^2.5.2",
     "run-sequence": "^1.1.5",
     "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "^1.1.0",
+    "watchify": "^3.7.0"
   }
 }


### PR DESCRIPTION
@funteractive 
## 背景

不具合修正しつつ、不便だったところの機能追加しました。
## 行ったこと
### Jade
- watchで下層フォルダも対象にする
- 「_」がついているファイルは出力しない
- エラーハンドリング追加（ミスしても止まらない＆通知出す）
### Sass
- csscombのソートを調整（.csscomb.json）
- autoprefixerをやめて、pleeease導入
- エラーハンドリング追加
### Sprite
- 出力先修正
- sprite-smithのコメントアウトがでないように、.sprite-template追加
### JS
- browserifyのwatchに、watchify導入。
  - 差分だけコンパイルされるようになったのではやくなった。
- エラーハンドリング追加（ミスしても止まらない＆通知出す）
